### PR TITLE
Add HTTPS setup script for local development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,17 @@ Open `examples/index.html` after running `npm run dev` to test the widget with v
 
 Unit tests use Jest with jsdom. Run `npm test` to execute the test suite.
 
+#### HTTPS for Local Development (macOS)
+
+If you need to test secure cookies (fingerprinting) locally, you can enable HTTPS:
+
+1. Install mkcert: `brew install mkcert`
+2. Run the setup script: `./setup-https.sh`
+3. Start the dev server: `npm run dev`
+4. Access via: `https://localhost:3333`
+
+The dev server automatically detects the presence of `localhost.pem` and `localhost-key.pem` certificates and enables HTTPS.
+
 ## API Payload
 
 The widget sends the following payload to the Coolhand API:

--- a/setup-https.sh
+++ b/setup-https.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo "Checking for SSL certificates..."
+
+# Check if certificates already exist
+if [ -f "localhost.pem" ] && [ -f "localhost-key.pem" ]; then
+    echo -e "${GREEN}✓ SSL certificates already exist${NC}"
+    exit 0
+fi
+
+echo -e "${YELLOW}SSL certificates not found. Generating...${NC}"
+
+# Check if mkcert is installed
+if ! command -v mkcert &> /dev/null; then
+    echo -e "${RED}Error: mkcert is not installed${NC}"
+    echo ""
+    echo "Please install mkcert first:"
+    echo "  macOS:   brew install mkcert"
+    echo "  Linux:   Follow instructions at https://github.com/FiloSottile/mkcert"
+    echo ""
+    echo "After installing, run this script again."
+    exit 1
+fi
+
+# Install local CA if needed (this is safe to run multiple times)
+echo "Installing local CA..."
+mkcert -install
+
+# Generate certificates
+echo "Generating localhost certificates..."
+mkcert -key-file localhost-key.pem -cert-file localhost.pem localhost 127.0.0.1 ::1
+
+if [ -f "localhost.pem" ] && [ -f "localhost-key.pem" ]; then
+    echo -e "${GREEN}✓ SSL certificates generated successfully!${NC}"
+    echo ""
+    echo "You can now run 'npm run dev' and access the site via https://localhost:3333"
+else
+    echo -e "${RED}Error: Failed to generate certificates${NC}"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds `setup-https.sh` script to generate mkcert SSL certificates
- Documents HTTPS setup process in CONTRIBUTING.md for macOS developers
- Enables testing of secure cookie features like fingerprinting locally

## Test plan
- [ ] Run `./setup-https.sh` to verify certificate generation works
- [ ] Confirm dev server uses HTTPS when certificates exist
- [ ] Verify dev server reverts to HTTP when certificates are removed